### PR TITLE
fix(demo): remove src/main resourceBase

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -229,7 +229,6 @@
 					<webAppConfig>
 						<resourceBases>
 							<resourceBase>src/test/resources/META-INF/resources</resourceBase>
-							<resourceBase>src/main/resources/META-INF/resources</resourceBase>
 						</resourceBases>
 					</webAppConfig>
 					<supportedPackagings>


### PR DESCRIPTION
Fix error when starting demo:

> [ERROR] Failed to execute goal org.eclipse.jetty:jetty-maven-plugin:9.4.36.v20210114:run (default-cli) on project github-buttons-addon: Unable to parse configuration of mojo org.eclipse.jetty:jetty-maven-plugin:9.4.36.v20210114:run for parameter resourceBases: Cannot set 'resourceBases' in class org.eclipse.jetty.maven.plugin.JettyWebAppContext: InvocationTargetException: file:///J:/fc/addons/GitHubButtons/src/main/resources/META-INF/resources is not an existing directory. -> [Help 1]